### PR TITLE
NXG-5 Convert subcommand

### DIFF
--- a/hs/cli/Main.hs
+++ b/hs/cli/Main.hs
@@ -64,15 +64,10 @@ stackAction args = do
 
 -- | Conversion between project specification formats.
 convertAction :: (MonadIO m, MonadThrow m) => ConvertArgs -> m ()
-convertAction ca@(ConvertArgs convertIn convertOut) = do
-    print ca
+convertAction (ConvertArgs convertIn convertOut) = do
     projectNative <- case convertIn of
       YamlConvertIn yamlPath -> projectYamlToProjectNative <$> readProjectYaml (toString yamlPath)
-      _                      -> throwM $ OtherError "Unsupported input format"
     case convertOut of
       StackConvertOut stackPath snapshotPath -> do
         let stackConfig = projectNativeToStackConfig projectNative
         writeStackConfig (toString stackPath) (toString snapshotPath) stackConfig
-      _ ->
-          throwM $ OtherError "Unsupported output format"
-

--- a/hs/cli/Main.hs
+++ b/hs/cli/Main.hs
@@ -3,59 +3,124 @@ import Universum
 import Data.Yaml (decodeFileEither, encodeFile)
 import Options.Applicative ( Parser, info, fullDesc, progDesc, header
                            , execParser, hsubparser, command
-                           , forwardOptions, strArgument, ParserInfo)
+                           , forwardOptions, strArgument, ParserInfo, Mod
+                           , CommandFields, optional, long, metavar, value
+                           , option, auto, helper)
 import System.IO.Temp (withSystemTempFile, withTempFile)
 import System.Process (waitForProcess, createProcess, delegate_ctlc, proc)
 
-import Nixage.Project.Yaml (projectYamlToProjectNative)
+import Nixage.Project.Yaml (ProjectYaml, projectYamlToProjectNative)
 import Nixage.Project.Types (NixageError(..))
-import Nixage.Convert.Stack (writeStackConfig, projectNativeToStackConfig)
+import Nixage.Convert.Stack (createStackFiles, projectNativeToStackConfig, StackConfig)
 
 main :: IO ()
 main = execParser (info nixageP infoMod) >>= \case
     StackCmd args -> stackAction args
+    ConvertCmd convertArgs -> convertAction convertArgs
   where
     infoMod = header "Nixage"
            <> progDesc "Build Haskell packages with Nix and Stackage"
            <> fullDesc
 
 
--- | * Nixage cli command type and parsers
+-- | * Nixage cli command types
 
-data NixageCmd = StackCmd StackArgs
+data NixageCmd =
+      StackCmd StackArgs
+    | ConvertCmd ConvertArgs
+
 type StackArgs = [Text]
 
-nixageP :: Parser NixageCmd
-nixageP = hsubparser $
-    command "stack" stackPI
+data ConvertArgs = ConvertArgs
+    { caInFormat :: InFormat            -- ^ Not optional (default in parser)
+    , caOutFromat :: OutFormat
+    , caInOutPath :: Maybe (Text, Text) -- ^ Optional (default from 'inFormat')
+    } deriving (Show)
 
-stackPI :: ParserInfo NixageCmd
-stackPI = info (StackCmd <$> stackP)
-        $ progDesc "Stack command" <> forwardOptions
+data InFormat = YamlInFormat  deriving (Read, Show)
+data OutFormat = StackOutFormat deriving (Read, Show)
+
+defaultInPath :: InFormat -> Text
+defaultInPath YamlInFormat = "project.yaml"
+
+defaultOutPath :: OutFormat -> Text
+defaultOutPath StackOutFormat = "stack.yaml"
+
+-- | * Nixage cli command parsers
+
+nixageP :: Parser NixageCmd
+nixageP = hsubparser $ mconcat nixageCmds
+
+nixageCmds :: [Mod CommandFields NixageCmd]
+nixageCmds =
+    [ command "stack" $ info (StackCmd <$> stackP) $
+           progDesc "Run stack on stack.yaml generated from project.yaml"
+        <> forwardOptions
+    , command "convert" $ info (ConvertCmd <$> convertP) $
+           progDesc "Convert between input formats (Yaml, Stack) "
+    ]
 
 -- | Parse all arguments after 'stack' command as raw [Text]
 stackP :: Parser StackArgs
 stackP = many $ strArgument mempty
 
+convertP :: Parser ConvertArgs
+convertP = ConvertArgs
+       <$> option auto (long "from" <> metavar "in-format" <> value YamlInFormat)
+       <*> option auto (long "to" <> metavar "out-format")
+       <*> inOutPathP
+  where
+      inOutPathP :: Parser (Maybe (Text, Text))
+      inOutPathP = (,)
+               <$> optional (strArgument $ metavar "in-path")
+               <*> optional (strArgument $ metavar "out-path") <&> \case
+               (Just inPath, Just outPath) -> Just (inPath, outPath)
+               _ ->  Nothing
 
--- | * Stack command actions
+
+-- | * Nixage command actions
+
+-- | read ProjectYaml from project.yaml
+readProjectYaml :: (MonadIO m, MonadThrow m) => FilePath -> m ProjectYaml
+readProjectYaml projectYamlPath =
+    liftIO (decodeFileEither projectYamlPath) >>= \case
+      Left err -> throwM $ YamlDecodingError (show err)
+      Right projectYaml -> return projectYaml
+
+
+-- | Write stack and snapshot yaml files
+writeStackConfig :: (MonadIO m, MonadThrow m)
+                 => FilePath     -- ^ Snapshot yaml path
+                 -> FilePath     -- ^ Stack yaml path
+                 -> StackConfig
+                 -> m ()
+writeStackConfig snapshotPath stackPath stackConfig = do
+   let (snapshot, stack) = createStackFiles stackConfig snapshotPath
+   liftIO $ do
+       encodeFile snapshotPath snapshot
+       encodeFile stackPath stack
 
 -- | Create temporary '[standard-tmp-dir]/nixage-snapshot[rand-num].yaml'
 -- and './nixage-stack[rand-num].yaml', and run 'stack' on them.
 stackAction :: (MonadIO m, MonadThrow m, MonadMask m) => StackArgs-> m ()
 stackAction args = do
-    liftIO (decodeFileEither "project.yaml") >>= \case
-      Left err -> throwM $ YamlDecodingError (show err)
-      Right projectYaml -> do
-        let projectNative = projectYamlToProjectNative projectYaml
-        let stackConfig = projectNativeToStackConfig projectNative
-        withSystemTempFile "nixage-stack-snapshot.yaml" $ \snapshotPath _ ->
-          withTempFile "." "nixage-stack.yaml" $ \stackPath _ -> do
-            let (snapshot, stack) = writeStackConfig stackConfig snapshotPath
-            let  args' = ["--stack-yaml", toText stackPath] <> args
-            liftIO $ do
-                encodeFile snapshotPath snapshot
-                encodeFile stackPath stack
-                (_,_,_,handle) <- createProcess $
-                    (proc "stack" (toString <$> args')) { delegate_ctlc = True }
-                void $ waitForProcess handle
+    projectYaml <- readProjectYaml "project.yaml"
+    let projectNative = projectYamlToProjectNative projectYaml
+    let stackConfig = projectNativeToStackConfig projectNative
+    withSystemTempFile "nixage-stack-snapshot.yaml" $ \snapshotPath _ ->
+      withTempFile "." "nixage-stack.yaml" $ \stackPath _ -> do
+        writeStackConfig snapshotPath stackPath stackConfig
+        let  args' = ["--stack-yaml", toText stackPath] <> args
+        liftIO $ do
+            (_,_,_,handle) <- createProcess $
+                (proc "stack" (toString <$> args')) { delegate_ctlc = True }
+            void $ waitForProcess handle
+
+convertAction :: (MonadIO m, MonadThrow m) => ConvertArgs -> m ()
+convertAction (ConvertArgs inFormat outFormat mInOutPath) = do
+    let (inPath, outPath) =
+          fromMaybe (defaultInPath inFormat, defaultOutPath outFormat) mInOutPath
+    projectNative <- case inFormat of
+        YamlInFormat -> projectYamlToProjectNative <$> readProjectYaml (toString inPath)
+    case outFormat of
+      StackOutFormat -> return ()

--- a/hs/cli/Main.hs
+++ b/hs/cli/Main.hs
@@ -14,8 +14,8 @@ import Types
 import Parser
 
 main :: IO ()
-main = execParser (info nixageP infoMod) >>= \case
-    StackCmd args -> stackAction args
+main = execParser (info (helper <*> nixageP) infoMod) >>= \case
+    StackCmd stackArgs     -> stackAction stackArgs
     ConvertCmd convertArgs -> convertAction convertArgs
   where
     infoMod = header "Nixage"
@@ -25,13 +25,12 @@ main = execParser (info nixageP infoMod) >>= \case
 
 -- | * Nixage command actions
 
--- | read ProjectYaml from file
+-- | read ProjectYaml from project.yaml
 readProjectYaml :: (MonadIO m, MonadThrow m) => FilePath -> m ProjectYaml
 readProjectYaml projectYamlPath =
     liftIO (decodeFileEither projectYamlPath) >>= \case
       Left err -> throwM $ YamlDecodingError (show err)
       Right projectYaml -> return projectYaml
-
 
 -- | Write stack and snapshot yaml files
 writeStackConfig :: (MonadIO m, MonadThrow m)
@@ -49,17 +48,19 @@ writeStackConfig stackPath snapshotPath stackConfig = do
 -- and './nixage-stack[rand-num].yaml', and run 'stack' on them.
 stackAction :: (MonadIO m, MonadThrow m, MonadMask m) => StackArgs-> m ()
 stackAction args = do
-    projectYaml <- readProjectYaml "project.yaml"
-    let projectNative = projectYamlToProjectNative projectYaml
-    let stackConfig = projectNativeToStackConfig projectNative
-    withSystemTempFile "nixage-stack-snapshot.yaml" $ \snapshotPath _ ->
-      withTempFile "." "nixage-stack.yaml" $ \stackPath _ -> do
-        writeStackConfig stackPath snapshotPath stackConfig
-        let  args' = ["--stack-yaml", toText stackPath] <> args
-        liftIO $ do
-            (_,_,_,handle) <- createProcess $
-                (proc "stack" (toString <$> args')) { delegate_ctlc = True }
-            void $ waitForProcess handle
+    liftIO (decodeFileEither "project.yaml") >>= \case
+      Left err -> throwM $ YamlDecodingError (show err)
+      Right projectYaml -> do
+        let projectNative = projectYamlToProjectNative projectYaml
+        let stackConfig = projectNativeToStackConfig projectNative
+        withSystemTempFile "nixage-stack-snapshot.yaml" $ \snapshotPath _ ->
+          withTempFile "." "nixage-stack.yaml" $ \stackPath _ -> do
+            writeStackConfig stackPath snapshotPath stackConfig
+            let  args' = ["--stack-yaml", toText stackPath] <> args
+            liftIO $ do
+                (_,_,_,handle) <- createProcess $
+                     (proc "stack" (toString <$> args')) { delegate_ctlc = True }
+                void $ waitForProcess handle
 
 -- | Conversion between project specification formats.
 convertAction :: (MonadIO m, MonadThrow m) => ConvertArgs -> m ()

--- a/hs/cli/Main.hs
+++ b/hs/cli/Main.hs
@@ -62,10 +62,9 @@ stackAction args = do
             void $ waitForProcess handle
 
 convertAction :: (MonadIO m, MonadThrow m) => ConvertArgs -> m ()
-convertAction (ConvertArgs inFormat outFormat mInOutPath) = do
-    let (inPath, outPath) =
-          fromMaybe (defaultInPath inFormat, defaultOutPath outFormat) mInOutPath
-    projectNative <- case inFormat of
-        YamlInFormat -> projectYamlToProjectNative <$> readProjectYaml (toString inPath)
-    case outFormat of
-      StackOutFormat -> return ()
+convertAction convertArgs = do
+    print convertArgs
+--    projectNative <- case inFormat of
+--        YamlInFormat -> projectYamlToProjectNative <$> readProjectYaml (toString inPath)
+--    case outFormat of
+--      StackOutFormat -> return ()

--- a/hs/cli/Parser.hs
+++ b/hs/cli/Parser.hs
@@ -1,0 +1,42 @@
+module Parser where
+
+-- |  Nixage cli command parsers
+--
+import Universum
+import Options.Applicative ( Parser, info, fullDesc, progDesc, header
+                           , hsubparser, command
+                           , forwardOptions, strArgument, ParserInfo, Mod
+                           , CommandFields, optional, long, metavar, value
+                           , option, auto, helper)
+
+import Types
+
+nixageP :: Parser NixageCmd
+nixageP = hsubparser $ mconcat nixageCmds
+
+nixageCmds :: [Mod CommandFields NixageCmd]
+nixageCmds =
+    [ command "stack" $ info (StackCmd <$> stackP) $
+           progDesc "Run stack on stack.yaml generated from project.yaml"
+        <> forwardOptions
+    , command "convert" $ info (ConvertCmd <$> convertP) $
+           progDesc "Convert between input formats (Yaml, Stack) "
+    ]
+
+-- | Parse all arguments after 'stack' command as raw [Text]
+stackP :: Parser StackArgs
+stackP = many $ strArgument mempty
+
+convertP :: Parser ConvertArgs
+convertP = ConvertArgs
+       <$> option auto (long "from" <> metavar "in-format" <> value YamlInFormat)
+       <*> option auto (long "to" <> metavar "out-format")
+       <*> inOutPathP
+  where
+      inOutPathP :: Parser (Maybe (Text, Text))
+      inOutPathP = (,)
+               <$> optional (strArgument $ metavar "in-path")
+               <*> optional (strArgument $ metavar "out-path") <&> \case
+               (Just inPath, Just outPath) -> Just (inPath, outPath)
+               _ ->  Nothing
+

--- a/hs/cli/Parser.hs
+++ b/hs/cli/Parser.hs
@@ -61,12 +61,6 @@ convertInPs =
       , YamlConvertIn <$> (strArgument $ metavar "project-yaml")
       , defConvertIn
       )
-    , ( "from-x"
-      , XConvertIn
-        <$> (strArgument $ metavar "x-in0" <> value "val-x-in0")
-        <*> (strOption $ long "x-in1" <> value "val-x-in1")
-      , XConvertIn "def-x-0" "def-x-1"
-      )
     ]
 
 -- Default ConvertIn
@@ -85,10 +79,6 @@ convertOutPs =
         <$> (strArgument $ metavar "stack-yaml")
         <*> (strArgument $ metavar "snapshot-yaml")
       , StackConvertOut "stack.yaml" "snapshot.yaml"
-      )
-    , ( "to-y"
-      , YConvertOut <$> (strArgument $ metavar "y-out")
-      , YConvertOut "def-y-out"
       )
     ]
 

--- a/hs/cli/Parser.hs
+++ b/hs/cli/Parser.hs
@@ -7,36 +7,53 @@ import Options.Applicative ( Parser, info, fullDesc, progDesc, header
                            , hsubparser, command
                            , forwardOptions, strArgument, ParserInfo, Mod
                            , CommandFields, optional, long, metavar, value
-                           , option, auto, helper)
+                           , option, auto, helper, strOption)
 
 import Types
 
 nixageP :: Parser NixageCmd
-nixageP = hsubparser $ mconcat nixageCmds
-
-nixageCmds :: [Mod CommandFields NixageCmd]
-nixageCmds =
-    [ command "stack" $ info (StackCmd <$> stackP) $
+nixageP = hsubparser $ mconcat
+    [ command "stack" $ info (StackCmd <$> stackArgsP) $
            progDesc "Run stack on stack.yaml generated from project.yaml"
         <> forwardOptions
-    , command "convert" $ info (ConvertCmd <$> convertP) $
+    , command "convert" $ info (ConvertCmd <$> convertArgsP) $
            progDesc "Convert between input formats (Yaml, Stack) "
     ]
 
 -- | Parse all arguments after 'stack' command as raw [Text]
-stackP :: Parser StackArgs
-stackP = many $ strArgument mempty
+stackArgsP :: Parser StackArgs
+stackArgsP = many $ strArgument mempty
 
-convertP :: Parser ConvertArgs
-convertP = ConvertArgs
-       <$> option auto (long "from" <> metavar "in-format" <> value YamlInFormat)
-       <*> option auto (long "to" <> metavar "out-format")
-       <*> inOutPathP
-  where
-      inOutPathP :: Parser (Maybe (Text, Text))
-      inOutPathP = (,)
-               <$> optional (strArgument $ metavar "in-path")
-               <*> optional (strArgument $ metavar "out-path") <&> \case
-               (Just inPath, Just outPath) -> Just (inPath, outPath)
-               _ ->  Nothing
+-- | Convert command parsers
+convertArgsP, yamlConvertInP, xConvertInP :: Parser ConvertArgs
+convertArgsP = hsubparser $ mconcat
+    [ command' "from-yaml" yamlConvertInP
+    , command' "from-x"    xConvertInP
+    , command' "to-stack"  $ ImplicitConvertIn <$> stackConvertOutP
+    , command' "to-y"      $ ImplicitConvertIn <$> yConvertOutP
+    ]
 
+yamlConvertInP = YamlConvertIn
+             <$> (strOption $ long "from" <> value "project.yaml" )
+             <*> convertOutP
+
+xConvertInP =  XConvertIn
+          <$> (strOption $ long "x-in")
+          <*> convertOutP
+
+
+convertOutP, stackConvertOutP, yConvertOutP :: Parser ConvertOut
+convertOutP = hsubparser $ mconcat
+    [ command' "to-stack" stackConvertOutP
+    , command' "to-y"     yConvertOutP
+    ]
+
+stackConvertOutP = StackConvertOut
+              <$> (strArgument $ metavar "stack-yaml" <> value "stack.yaml")
+              <*> (strArgument $ metavar "snapshot-yaml" <> value "snapshot.yaml")
+
+yConvertOutP = YConvertOut
+           <$> (strArgument $ metavar "y-out")
+
+command' :: String -> Parser a -> Mod CommandFields a
+command' cmd subP = command cmd $ info subP mempty

--- a/hs/cli/Types.hs
+++ b/hs/cli/Types.hs
@@ -4,21 +4,19 @@ module Types where
 
 import Universum
 
-data NixageCmd =
-      StackCmd StackArgs
+data NixageCmd
+    = StackCmd StackArgs
     | ConvertCmd ConvertArgs
-      deriving (Show)
+    deriving (Show)
 
 type StackArgs = [Text]
 
 data ConvertArgs = ConvertArgs ConvertIn ConvertOut deriving (Show)
 
-data ConvertIn =
-      YamlConvertIn Text
-    | XConvertIn Text Text
-      deriving (Show)
+data ConvertIn
+    = YamlConvertIn Text
+    deriving (Show)
 
-data ConvertOut =
-      StackConvertOut Text Text
-    | YConvertOut Text
-      deriving (Show)
+data ConvertOut
+    = StackConvertOut Text Text
+    deriving (Show)

--- a/hs/cli/Types.hs
+++ b/hs/cli/Types.hs
@@ -1,0 +1,27 @@
+module Types where
+
+-- |  Nixage cli command types
+
+import Universum
+
+data NixageCmd =
+      StackCmd StackArgs
+    | ConvertCmd ConvertArgs
+
+type StackArgs = [Text]
+
+data ConvertArgs = ConvertArgs
+    { caInFormat :: InFormat            -- ^ Not optional (default in parser)
+    , caOutFromat :: OutFormat
+    , caInOutPath :: Maybe (Text, Text) -- ^ Optional (default from 'inFormat')
+    } deriving (Show)
+
+data InFormat = YamlInFormat  deriving (Read, Show)
+data OutFormat = StackOutFormat deriving (Read, Show)
+
+defaultInPath :: InFormat -> Text
+defaultInPath YamlInFormat = "project.yaml"
+
+defaultOutPath :: OutFormat -> Text
+defaultOutPath StackOutFormat = "stack.yaml"
+

--- a/hs/cli/Types.hs
+++ b/hs/cli/Types.hs
@@ -7,21 +7,17 @@ import Universum
 data NixageCmd =
       StackCmd StackArgs
     | ConvertCmd ConvertArgs
+      deriving (Show)
 
 type StackArgs = [Text]
 
-data ConvertArgs = ConvertArgs
-    { caInFormat :: InFormat            -- ^ Not optional (default in parser)
-    , caOutFromat :: OutFormat
-    , caInOutPath :: Maybe (Text, Text) -- ^ Optional (default from 'inFormat')
-    } deriving (Show)
+data ConvertArgs =
+      YamlConvertIn Text ConvertOut
+    | XConvertIn Text ConvertOut
+    | ImplicitConvertIn ConvertOut
+      deriving (Show)
 
-data InFormat = YamlInFormat  deriving (Read, Show)
-data OutFormat = StackOutFormat deriving (Read, Show)
-
-defaultInPath :: InFormat -> Text
-defaultInPath YamlInFormat = "project.yaml"
-
-defaultOutPath :: OutFormat -> Text
-defaultOutPath StackOutFormat = "stack.yaml"
-
+data ConvertOut =
+      StackConvertOut Text Text
+    | YConvertOut Text
+      deriving (Show)

--- a/hs/cli/Types.hs
+++ b/hs/cli/Types.hs
@@ -11,10 +11,11 @@ data NixageCmd =
 
 type StackArgs = [Text]
 
-data ConvertArgs =
-      YamlConvertIn Text ConvertOut
-    | XConvertIn Text ConvertOut
-    | ImplicitConvertIn ConvertOut
+data ConvertArgs = ConvertArgs ConvertIn ConvertOut deriving (Show)
+
+data ConvertIn =
+      YamlConvertIn Text
+    | XConvertIn Text Text
       deriving (Show)
 
 data ConvertOut =

--- a/hs/lib/Nixage/Convert/Stack.hs
+++ b/hs/lib/Nixage/Convert/Stack.hs
@@ -42,8 +42,9 @@ instance ToJSON StackCustomSnapshot where
                    , "subdirs" .= [fromMaybe "." subdir]
                    ]
 
-writeStackConfig :: StackConfig -> FilePath -> (Value, Value)
-writeStackConfig (StackConfig snapshot packages) snapshotPath =
+-- | Create stack and snapshot yaml files content
+createStackFiles :: StackConfig -> FilePath -> (Value, Value)
+createStackFiles (StackConfig snapshot packages) snapshotPath =
     (toJSON snapshot, stackYamlBuilder)
   where
     stackYamlBuilder = object

--- a/hs/lib/Nixage/Project/Types.hs
+++ b/hs/lib/Nixage/Project/Types.hs
@@ -59,6 +59,7 @@ data ExternalSource
 data NixageError =
       ProjectNativeToStackConfigError Text
     | YamlDecodingError Text
+    | OtherError Text
     deriving (Show, Typeable)
 
 instance Exception NixageError

--- a/hs/shell.nix
+++ b/hs/shell.nix
@@ -1,9 +1,8 @@
 let
   x = import ./default.nix {};
-  pkgs = x.pkgs;
-  p = x.nixageProj;
-in p.haskellPackages.shellFor {
-  packages = (_: pkgs.lib.attrValues p.target);
+  pkgs = x._pkgs;
+in x._haskellPackages.shellFor {
+  packages = (_: pkgs.lib.attrValues x._target);
   nativeBuildInputs = with pkgs.haskellPackages; [ cabal-install ];
 
   shellHook = ''


### PR DESCRIPTION
Parser for ConvertArgs is defined by defining (cmd name, parser, default value) for each input and output format constructor.
First, nested subcommands for input and output are parsed and then, corresponding input/output arguments are parsed. Mock input and output (x, y) are added to demonstrate different arguments based on format.
Example usage:
``` nixage convert from-yaml to-stack
nixage convert from-yaml to-stack new-project.yaml new-stack.yaml new-snapshot.yaml
nixage convert to-stack
nixage convert to-stack new-stack.yaml new-snapshot.yaml
```